### PR TITLE
refactor: Moved available colors to Canvas contants

### DIFF
--- a/DrawingApp/Views/Canvas/CanvasConstants.swift
+++ b/DrawingApp/Views/Canvas/CanvasConstants.swift
@@ -5,7 +5,7 @@
 //  Created by Steven Santeliz on 1/6/24.
 //
 
-import Foundation
+import SwiftUI
 
 enum CanvasConstants {
     static let buttonSpacing: CGFloat = 12
@@ -23,7 +23,15 @@ enum CanvasConstants {
         static let yPosition: CGFloat = 15
     }
     
-    enum ColorBtn {
+    // MARK: - Drawing colors
+    
+    enum Drawing {
+        static let colors: [Color] = [.red, .blue, .black, .orange, .green, .purple, .brown]
+    }
+    
+    // MARK: - Button constants
+    
+    enum Button {
         static let size: CGFloat = 25
         static let lineWidth: CGFloat = 2
         

--- a/DrawingApp/Views/Canvas/CanvasView.swift
+++ b/DrawingApp/Views/Canvas/CanvasView.swift
@@ -13,7 +13,6 @@ struct CanvasView: View {
     @State private var selectedColor: Color = .red
     
     private typealias Constants = CanvasConstants
-    private let colors: [Color] = [.red, .blue, .black, .orange, .green, .purple, .brown]
     
     var body: some View {
         VStack {
@@ -36,7 +35,7 @@ struct CanvasView: View {
     private var headerView: some View {
         VStack {
             HStack(spacing: Constants.buttonSpacing) {
-                ForEach(colors, id: \.self) { color in
+                ForEach(Constants.Drawing.colors, id: \.self) { color in
                     colorButton(color)
                 }
                 
@@ -87,13 +86,16 @@ struct CanvasView: View {
         } label: {
             customImage(selectedColor == color ? .colorFill : .color)
                 .resizable()
-                .frame(width: Constants.ColorBtn.size, height: Constants.ColorBtn.size)
+                .frame(width: Constants.Button.size, height: Constants.Button.size)
                 .foregroundStyle(color)
                 .background {
-                    Circle().strokeBorder(color, lineWidth: Constants.ColorBtn.lineWidth)
-                        .scaleEffect(selectedColor == color ? Constants.ColorBtn.ScaleEffect.max : Constants.ColorBtn.ScaleEffect.min)
-                        .opacity(selectedColor == color ? Constants.ColorBtn.Opacity.max : Constants.ColorBtn.Opacity.min)
-                        .animation(.bouncy(duration: Constants.ColorBtn.Animation.duration, extraBounce: Constants.ColorBtn.Animation.extraBounce), value: selectedColor)
+                    Circle()
+                        .strokeBorder(color, lineWidth: Constants.Button.lineWidth)
+                        .scaleEffect(selectedColor == color ? Constants.Button.ScaleEffect.max : Constants.Button.ScaleEffect.min)
+                        .opacity(selectedColor == color ? Constants.Button.Opacity.max : Constants.Button.Opacity.min)
+                        .animation(.bouncy(duration: Constants.Button.Animation.duration,
+                                           extraBounce: Constants.Button.Animation.extraBounce),
+                                   value: selectedColor)
                 }
         }
     }


### PR DESCRIPTION
### Description

This PR splits the view logic with the declaration of the available colors to be used in the app.

- Moved the `colors` properties to `CanvasConstants` enum.
- Renamed the `ColorsBtn` enum using `Button` name.

### Medias

https://github.com/santelizvargas/Creative-Canvas/assets/74283575/c6532ab7-0ae6-42f4-b983-dc98fe613343

### Testplan

- I was drawing using multiple colors.

